### PR TITLE
Fix issue where breaking compressed coal drops compressed birch

### DIFF
--- a/src/main/resources/data/compressedblocks/loot_tables/blocks/compressed_coal_x2.json
+++ b/src/main/resources/data/compressedblocks/loot_tables/blocks/compressed_coal_x2.json
@@ -7,7 +7,7 @@
       "entries": [
         {
           "type": "minecraft:item",
-          "name": "compressedblocks:compressed_birch_x2"
+          "name": "compressedblocks:compressed_coal_x2"
         }
       ],
       "conditions": [

--- a/src/main/resources/data/compressedblocks/loot_tables/blocks/compressed_coal_x3.json
+++ b/src/main/resources/data/compressedblocks/loot_tables/blocks/compressed_coal_x3.json
@@ -7,7 +7,7 @@
       "entries": [
         {
           "type": "minecraft:item",
-          "name": "compressedblocks:compressed_birch_x3"
+          "name": "compressedblocks:compressed_coal_x3"
         }
       ],
       "conditions": [

--- a/src/main/resources/data/compressedblocks/loot_tables/blocks/compressed_coal_x4.json
+++ b/src/main/resources/data/compressedblocks/loot_tables/blocks/compressed_coal_x4.json
@@ -7,7 +7,7 @@
       "entries": [
         {
           "type": "minecraft:item",
-          "name": "compressedblocks:compressed_birch_x4"
+          "name": "compressedblocks:compressed_coal_x4"
         }
       ],
       "conditions": [

--- a/src/main/resources/data/compressedblocks/loot_tables/blocks/compressed_coal_x5.json
+++ b/src/main/resources/data/compressedblocks/loot_tables/blocks/compressed_coal_x5.json
@@ -7,7 +7,7 @@
       "entries": [
         {
           "type": "minecraft:item",
-          "name": "compressedblocks:compressed_birch_x5"
+          "name": "compressedblocks:compressed_coal_x5"
         }
       ],
       "conditions": [

--- a/src/main/resources/data/compressedblocks/loot_tables/blocks/compressed_coal_x6.json
+++ b/src/main/resources/data/compressedblocks/loot_tables/blocks/compressed_coal_x6.json
@@ -7,7 +7,7 @@
       "entries": [
         {
           "type": "minecraft:item",
-          "name": "compressedblocks:compressed_birch_x6"
+          "name": "compressedblocks:compressed_coal_x6"
         }
       ],
       "conditions": [

--- a/src/main/resources/data/compressedblocks/loot_tables/blocks/compressed_coal_x7.json
+++ b/src/main/resources/data/compressedblocks/loot_tables/blocks/compressed_coal_x7.json
@@ -7,7 +7,7 @@
       "entries": [
         {
           "type": "minecraft:item",
-          "name": "compressedblocks:compressed_birch_x7"
+          "name": "compressedblocks:compressed_coal_x7"
         }
       ],
       "conditions": [

--- a/src/main/resources/data/compressedblocks/loot_tables/blocks/compressed_coal_x8.json
+++ b/src/main/resources/data/compressedblocks/loot_tables/blocks/compressed_coal_x8.json
@@ -7,7 +7,7 @@
       "entries": [
         {
           "type": "minecraft:item",
-          "name": "compressedblocks:compressed_birch_x8"
+          "name": "compressedblocks:compressed_coal_x8"
         }
       ],
       "conditions": [


### PR DESCRIPTION
This PR fixes an issue where breaking compressed coal 2x and up would drop the respective density birch log block.